### PR TITLE
hailoexportfile_pts added PTS to hailoexportfile

### DIFF
--- a/core/hailo/plugins/export/export_file/gsthailoexportfile.cpp
+++ b/core/hailo/plugins/export/export_file/gsthailoexportfile.cpp
@@ -187,6 +187,10 @@ gst_hailoexportfile_transform_ip(GstBaseTransform *trans,
     encoded_roi.AddMember("timestamp (ms)", rapidjson::Value(timenow), encoded_roi.GetAllocator());
     encoded_roi.AddMember("buffer_offset", rapidjson::Value(hailoexportfile->buffer_offset), encoded_roi.GetAllocator());
 
+    // Add a pts
+    GstClockTime pts = GST_BUFFER_PTS(buffer);
+    encoded_roi.AddMember("pts (ns)", rapidjson::Value(pts), encoded_roi.GetAllocator());
+
     // Add the stream-id
     std::string stream_id = hailo_roi->get_stream_id();
 


### PR DESCRIPTION
Hailoexportfile saves all detections to a JSON file. It makes sense to also save the buffer PTS of the detection to later map the detections to the exact frames. Using "timestamp (ms)" alone wouldn't be sufficient for mapping the detections to the frames, as this timestamp represents the moment the detection is written to the file and does not correspond to the buffer timestamp.